### PR TITLE
add 'options' param to declaration in index.d.ts

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,3 +1,3 @@
 type Variant = 'RFC3548' | 'RFC4648' | 'RFC4648-HEX' | 'Crockford'
-declare function base32Encode(buffer: ArrayBuffer, variant: Variant): string
+declare function base32Encode(buffer: ArrayBuffer, variant: Variant, options: any): string
 export = base32Encode


### PR DESCRIPTION
When the new 'options' parameter was added to the base32Encode function, it didn't get added to the TypeScript declaration in index.d.ts.