### PR TITLE
💥 Convert package to ESM

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,24 @@
+name: Node CI
+
+on:
+  pull_request:
+    branches:
+    - master
+
+jobs:
+  test:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macOS-latest]
+        node: [12.20.0, 14.13.1, 16.0.0]
+    runs-on: ${{ matrix.os }}
+    steps:
+    - uses: actions/checkout@v2
+    - name: Use Node.js ${{ matrix.node }}
+      uses: actions/setup-node@v2
+      with:
+        node-version: ${{ matrix.node }}
+    - name: Install dependencies
+      run: npm install
+    - name: Run tests
+      run: npm test

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,1 @@
 /node_modules/
-/npm-debug.log

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2016-2017 Linus Unnebäck
+Copyright (c) 2016-2021 Linus Unnebäck
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/index.d.ts
+++ b/index.d.ts
@@ -19,5 +19,4 @@ declare namespace base32Encode {
  * @param variant
  * @param options
  */
-declare function base32Encode(data: ArrayBuffer | Int8Array | Uint8Array | Uint8ClampedArray, variant: 'RFC3548' | 'RFC4648' | 'RFC4648-HEX' | 'Crockford', options?: base32Encode.Options): string
-export = base32Encode
+export default function base32Encode(data: ArrayBuffer | Int8Array | Uint8Array | Uint8ClampedArray, variant: 'RFC3548' | 'RFC4648' | 'RFC4648-HEX' | 'Crockford', options?: base32Encode.Options): string

--- a/index.js
+++ b/index.js
@@ -1,12 +1,12 @@
-var toDataView = require('to-data-view')
+import toDataView from 'to-data-view'
 
-var RFC4648 = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ234567'
-var RFC4648_HEX = '0123456789ABCDEFGHIJKLMNOPQRSTUV'
-var CROCKFORD = '0123456789ABCDEFGHJKMNPQRSTVWXYZ'
+const RFC4648 = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ234567'
+const RFC4648_HEX = '0123456789ABCDEFGHIJKLMNOPQRSTUV'
+const CROCKFORD = '0123456789ABCDEFGHJKMNPQRSTVWXYZ'
 
-module.exports = function base32Encode (data, variant, options) {
+export default function base32Encode (data, variant, options) {
   options = options || {}
-  var alphabet, defaultPadding
+  let alphabet, defaultPadding
 
   switch (variant) {
     case 'RFC3548':
@@ -26,14 +26,14 @@ module.exports = function base32Encode (data, variant, options) {
       throw new Error('Unknown base32 variant: ' + variant)
   }
 
-  var padding = (options.padding !== undefined ? options.padding : defaultPadding)
-  var view = toDataView(data)
+  const padding = (options.padding !== undefined ? options.padding : defaultPadding)
+  const view = toDataView(data)
 
-  var bits = 0
-  var value = 0
-  var output = ''
+  let bits = 0
+  let value = 0
+  let output = ''
 
-  for (var i = 0; i < view.byteLength; i++) {
+  for (let i = 0; i < view.byteLength; i++) {
     value = (value << 8) | view.getUint8(i)
     bits += 8
 

--- a/package.json
+++ b/package.json
@@ -3,15 +3,17 @@
   "version": "1.2.0",
   "license": "MIT",
   "repository": "LinusU/base32-encode",
+  "type": "module",
+  "exports": "./index.js",
   "scripts": {
     "test": "standard && node test && ts-readme-generator --check"
   },
   "dependencies": {
-    "to-data-view": "^1.1.0"
+    "to-data-view": "^2.0.0"
   },
   "devDependencies": {
-    "hex-to-array-buffer": "^0.1.0",
-    "standard": "^8.0.0-beta.5",
+    "hex-to-array-buffer": "^2.0.0",
+    "standard": "^16.0.3",
     "ts-readme-generator": "^0.5.1"
   },
   "keywords": [
@@ -23,5 +25,8 @@
     "encoder",
     "rfc3548",
     "rfc4648"
-  ]
+  ],
+  "engines": {
+    "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+  }
 }

--- a/readme.md
+++ b/readme.md
@@ -11,7 +11,7 @@ npm install --save base32-encode
 ## Usage
 
 ```js
-const base32Encode = require('base32-encode')
+import base32Encode from 'base32-encode'
 const data = new Uint8Array([0x74, 0x65, 0x73, 0x74])
 
 console.log(base32Encode(data, 'Crockford'))

--- a/test.js
+++ b/test.js
@@ -1,8 +1,8 @@
-var assert = require('assert')
-var base32Encode = require('./')
-var hexToArrayBuffer = require('hex-to-array-buffer')
+import assert from 'node:assert'
+import hexToArrayBuffer from 'hex-to-array-buffer'
+import base32Encode from './index.js'
 
-var testCases = [
+const testCases = [
   // RFC 4648 - Test vectors
   ['RFC4648', '', ''],
   ['RFC4648', '66', 'MY======'],


### PR DESCRIPTION
Migration Guide:

This relases changes the package from a Common JS module to an EcmaScript module, and drops support for older versions of Node.

- The minimum version of Node.js supported is now: `12.20.0`, `14.13.1`, and `16.0.0`
- The package must now be imported using the native `import` syntax instead of with `require`